### PR TITLE
Support for nullary context transformer methods

### DIFF
--- a/src/main/scala/flow.scala
+++ b/src/main/scala/flow.scala
@@ -190,6 +190,7 @@ class FlowMacros(val c: blackbox.Context){
                   unit(q"(..$values)")
                 }
                 val params = scope.map{ case(name, tpe) => ValDef(Modifiers(Flag.PARAM),name,tpe,EmptyTree) }
+                /// FIXME: use fresh name instead of lll
                 (scope, continue => q"""
                   val lll = ${refocus(transformerT, transformer, captured)}
                   lll.flatMap{

--- a/src/test/scala/Test.scala
+++ b/src/test/scala/Test.scala
@@ -69,6 +69,35 @@ class Tests extends FunSuite with org.scalactic.TypeCheckedTripleEquals {
         l1 * l2
       }
     )
+
+    assert(
+      List(15,18,20,24,30,36,40,48) == sequence[List]{ c =>
+        val l1 = ~List(1,2)
+        val l2 = ~List(3,4)
+        val l3 = ~List(5,6)
+        l3 * l1 * l2
+      }
+    )
+
+    assert(
+      List(48,40,36,30,24,20,18,15) == sequence[List]{ c =>
+        val l1 = ~List(1,2)
+        val l2 = ~List(3,4)
+        val l3 = ~List(5,6)
+        c.reverse
+        l3 * l1 * l2
+      }
+    )
+
+    assert(
+      List(40,48,30,36,20,24,15,18) == sequence[List]{ c =>
+        val l1 = ~List(1,2)
+        val l2 = ~List(3,4)
+        c.reverse
+        val l3 = ~List(5,6)
+        l3 * l1 * l2
+      }
+    )
 /*
     assert(
       List(6,8) == sequence[List]{ c =>

--- a/src/test/scala/Test.scala
+++ b/src/test/scala/Test.scala
@@ -34,10 +34,10 @@ class Tests extends FunSuite with org.scalactic.TypeCheckedTripleEquals {
         o1 * o2
       }
     )
+
     assert(
       Option(15) == sequence[Option]{ c =>
         val o1 = ~Option(5)
-        println("x")
         val o2 = ~Option(3)
         o1 * o2
       }
@@ -51,6 +51,33 @@ class Tests extends FunSuite with org.scalactic.TypeCheckedTripleEquals {
         x * o1 * o2
       }
     )
+
+    assert(
+      List(3,4,6,8) == sequence[List]{ c =>
+        val l1 = ~List(1,2)
+        val l2 = ~List(3,4)
+        l1 * l2
+      }
+    )
+
+
+    assert(
+      List(8,6,4,3) == sequence[List]{ c =>
+        val l1 = ~List(1,2)
+        val l2 = ~List(3,4)
+        c.reverse
+        l1 * l2
+      }
+    )
+/*
+    assert(
+      List(6,8) == sequence[List]{ c =>
+        val l1 = ~List(1,2)
+        val l2 = ~List(3,4)
+        c.filter(l1 >= 2)
+        l1 * l2
+      }
+    )*/
     /* // crashes scalac
     assert(
       Option(5) == sequence[Option]{ c =>


### PR DESCRIPTION
review by @clhodapp

figured out that continuations nicely allow us to forward traverse the statements while still building up the nested code outside in, but letting the next step decide how exactly, this if needed we can wrap up the iteration, call transformer methods on it, assign it to a val and restart the iteration.

Yes `lll` should be replaced by fresh name next time we get a chance.
